### PR TITLE
Option for WP API prefix

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -119,7 +119,7 @@ class HttpClient
      */
     protected function buildApiUrl($url)
     {
-        $api = $this->options->isWPAPI() ? '/wp-json/' : '/wc-api/';
+        $api = $this->options->isWPAPI() ? $this->options->apiPrefix() : '/wc-api/';
 
         return \rtrim($url, '/') . $api . $this->options->getVersion() . '/';
     }

--- a/src/WooCommerce/HttpClient/Options.php
+++ b/src/WooCommerce/HttpClient/Options.php
@@ -27,6 +27,12 @@ class Options
     const TIMEOUT = 15;
 
     /**
+     * Default WP API prefix.
+     * Including leading and trailing slashes.
+     */
+    const WP_API_PREFIX = '/wp-json/';
+
+    /**
      * Options.
      *
      * @var array
@@ -92,5 +98,15 @@ class Options
     public function isWPAPI()
     {
         return isset($this->options['wp_api']) ? (bool) $this->options['wp_api'] : false;
+    }
+
+    /**
+     * Custom API Prefix for WP API.
+     * 
+     * @return string
+     */
+    public function apiPrefix()
+    {
+        return isset($this->options['api_prefix']) ? $this->options['api_prefix'] : self::WP_API_PREFIX;
     }
 }

--- a/tests/WooCommerce/Tests/HttpClient/OptionsTest.php
+++ b/tests/WooCommerce/Tests/HttpClient/OptionsTest.php
@@ -38,4 +38,9 @@ class OptionsTest extends TestCase
     {
         $this->assertFalse($this->options->isWPAPI());
     }
+
+    public function testDefaultValueOfIsApiPrefix()
+    {
+        $this->assertEquals('/wp-json/', $this->options->apiPrefix());
+    }
 }


### PR DESCRIPTION
This introduces a new option `api_prefix` - that can be used to customise the WP API prefix used. By default it is `/wp-json/`. Test included.

Closes #49