### PR TITLE
Expose Response::getHeaders to Client

### DIFF
--- a/src/WooCommerce/Client.php
+++ b/src/WooCommerce/Client.php
@@ -44,6 +44,17 @@ class Client
     }
 
     /**
+     * Get headers from last response
+     * @return array
+    */
+    public function getHeaders()
+    {
+        $resp = $this->http->getResponse();
+
+        return is_object($resp) ? $resp->getHeaders() : array();
+    }
+
+    /**
      * POST method.
      *
      * @param string $endpoint API endpoint.


### PR DESCRIPTION
I might be doing something wrong, but it seems difficult to work with paged result sets if the `Client` doesn't have access to the response headers and the total size of the data set is unknown.