### PR TITLE
Show malformed JSON response body

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -342,7 +342,11 @@ class HttpClient
 
         // Test if return a valid JSON.
         if (JSON_ERROR_NONE !== json_last_error()) {
-            $message = function_exists('json_last_error_msg') ? json_last_error_msg() : 'Invalid JSON returned';
+            $message = sprintf(
+                '%s: %s',
+                function_exists('json_last_error_msg') ? json_last_error_msg() : 'Invalid JSON returned',
+                \var_export($body, true)
+            );
             throw new HttpClientException($message, $this->response->getCode(), $this->request, $this->response);
         }
 


### PR DESCRIPTION
It would be helpful to see the malformed JSON from the response body. I had to edit the file to get the more verbose error info.

![ss_2017-08-08-15-33-54](https://user-images.githubusercontent.com/454800/29074398-799ae786-7c4f-11e7-9b4b-44788c925838.jpg)
