### PR TITLE
Allow curl to follow redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ $woocommerce = new Client(
 | `wp_api_prefix`     | `string` | no       | Custom WP REST API URL prefix, used to support custom prefixes created with the `rest_url_prefix` filter               |
 | `version`           | `string` | no       | API version, default is `v3`                                                                                           |
 | `timeout`           | `int`    | no       | Request timeout, default is `15`                                                                                       |
+| `follow_redirects`  | `bool`   | no       | Allow the API call to follow redirects                                                                                 |
 | `verify_ssl`        | `bool`   | no       | Verify SSL when connect, use this option as `false` when need to test with self-signed certificates, default is `true` |
 | `query_string_auth` | `bool`   | no       | Force Basic Authentication as query string when `true` and using under HTTPS, default is `false`                       |
 | `oauth_timestamp`   | `string` | no       | Custom oAuth timestamp, default is `time()`                                                                            |

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -288,12 +288,16 @@ class HttpClient
      */
     protected function setDefaultCurlSettings()
     {
-        $verifySsl = $this->options->verifySsl();
-        $timeout   = $this->options->getTimeout();
+        $verifySsl       = $this->options->verifySsl();
+        $timeout         = $this->options->getTimeout();
+        $followRedirects = $this->options->getFollowRedirects();
 
         \curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, $verifySsl);
         if (!$verifySsl) {
             \curl_setopt($this->ch, CURLOPT_SSL_VERIFYHOST, $verifySsl);
+        }
+        if ($followRedirects) {
+            \curl_setopt($this->ch, CURLOPT_FOLLOWLOCATION, $followRedirects);
         }
         \curl_setopt($this->ch, CURLOPT_CONNECTTIMEOUT, $timeout);
         \curl_setopt($this->ch, CURLOPT_TIMEOUT, $timeout);

--- a/src/WooCommerce/HttpClient/Options.php
+++ b/src/WooCommerce/HttpClient/Options.php
@@ -141,7 +141,8 @@ class Options
      *
      * @return bool
      */
-    public function getFollowRedirects() {
+    public function getFollowRedirects()
+    {
         return isset($this->options['follow_redirects']) ? (bool)$this->options['follow_redirects'] : false;
 
     }

--- a/src/WooCommerce/HttpClient/Options.php
+++ b/src/WooCommerce/HttpClient/Options.php
@@ -135,4 +135,14 @@ class Options
     {
         return isset($this->options['user_agent']) ? $this->options['user_agent'] : self::USER_AGENT;
     }
+
+    /**
+     * Get follow redirects
+     *
+     * @return bool
+     */
+    public function getFollowRedirects() {
+        return isset($this->options['follow_redirects']) ? (bool)$this->options['follow_redirects'] : false;
+
+    }
 }


### PR DESCRIPTION
### Description
Some WooCommerce stores return a redirect for api calls where the query string with the credentials (consumer_key and consumer_secret) is included in the url.

For example `https://my-store.com?consumer_key=x&consumer_secret=y` will return a redirect to `https://my-store.com/?consumer_key=x&consumer_secret=y`. Since the curl object is not setting the curl opt `CURL_FOLLOWLOCATION` it will just return the html response and will also trigger a syntax error due to the failure to decode the JSON.

### What this PR solves
If the WooCommerce client is configured to follow redirect than any 301 will just work without needing to adjust the URL. I would think that this should be a default option but I guess it's a good idea to leave it optional as well.