### PR TITLE
Don't force decode json to be nested Arrays as this won't make the endpoint JSON Schemas

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -315,9 +315,9 @@ class HttpClient
     {
         // Any non-200/201/202 response code indicates an error.
         if (!\in_array($this->response->getCode(), ['200', '201', '202'])) {
-            $errors = isset( $parsedResponse->errors ) ? $parsedResponse->errors : $parsedResponse;
+            $errors = isset($parsedResponse->errors) ? $parsedResponse->errors : $parsedResponse;
 
-            if ( is_array( $errors ) ) {
+            if (is_array($errors)) {
                 $errorMessage = $errors[0]['message'];
                 $errorCode    = $errors[0]['code'];
             } else {

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -342,7 +342,7 @@ class HttpClient
            $body = substr($body, 3);
         }
 
-        $parsedResponse = \json_decode($body, true);
+        $parsedResponse = \json_decode($body);
 
         // Test if return a valid JSON.
         if (JSON_ERROR_NONE !== json_last_error()) {

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -315,14 +315,16 @@ class HttpClient
     {
         // Any non-200/201/202 response code indicates an error.
         if (!\in_array($this->response->getCode(), ['200', '201', '202'])) {
-            $errors = !empty($parsedResponse['errors']) ? $parsedResponse['errors'] : $parsedResponse;
+            $errors = isset( $parsedResponse->errors ) ? $parsedResponse->errors : $parsedResponse;
 
-            if (!empty($errors[0])) {
+			error_log( print_r( $errors, true ) );
+
+            if ( is_array( $errors ) ) {
                 $errorMessage = $errors[0]['message'];
                 $errorCode    = $errors[0]['code'];
             } else {
-                $errorMessage = $errors['message'];
-                $errorCode    = $errors['code'];
+                $errorMessage = $errors->message;
+                $errorCode    = $errors->code;
             }
 
             throw new HttpClientException(\sprintf('Error: %s [%s]', $errorMessage, $errorCode), $this->response->getCode(), $this->request, $this->response);

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -317,8 +317,6 @@ class HttpClient
         if (!\in_array($this->response->getCode(), ['200', '201', '202'])) {
             $errors = isset( $parsedResponse->errors ) ? $parsedResponse->errors : $parsedResponse;
 
-			error_log( print_r( $errors, true ) );
-
             if ( is_array( $errors ) ) {
                 $errorMessage = $errors[0]['message'];
                 $errorCode    = $errors[0]['code'];


### PR DESCRIPTION
WordPress 4.9 starts [enforcing API Schemas](https://core.trac.wordpress.org/changeset/41727) which means in order to easily use the WooCommerce API we need to respect the object/array structure in responses.

If we don't do this all clients need to restructure the data returned as well as updating it when trying to update something.

Example psuedo code that worked prior to WP4.9:

```
require __DIR__ . '/vendor/autoload.php';

use Automattic\WooCommerce\Client;

$woocommerce = new Client(
    'http://example.com', 
    'ck_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 
    'cs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
    [
        'wp_api' => true,
        'version' => 'wc/v1',
    ]
);

$customer = $woocommerce->get('customer/1');
$customer['billing']['email'] = 'new.email@address';
$woocommerce->put('customer/1', $customer);
```

This now fails post 4.9 as the supplied data doesn't validate against the schema for the endpoint - WooCommerce expects a structure of nested objects not the nested arrays as documented in the PHP examples on http://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-customer

This 'bug' was effectively introduced in 5f3eaef5b45aedf5f6d61c5bd30c3d867c1aa1b2

We also probably need to update all the examples in the documentation, and this will likely break any existing PHP clients as it isn't backwards compatible (they are likely broken by WP4.9 anyways).