### PR TITLE
Request Headers as new Client Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ $woocommerce = new Client(
 | `query_string_auth` | `bool`   | no       | Force Basic Authentication as query string when `true` and using under HTTPS, default is `false`                       |
 | `oauth_timestamp`   | `string` | no       | Custom oAuth timestamp, default is `time()`                                                                            |
 | `user_agent`        | `string` | no       | Custom user-agent, default is `WooCommerce API Client-PHP`                                                             |
+| `requestHeaders`    | `array`  | no       | Custom Request Headers (see [Client options - requestHeaders usage](#client-options-requestheaders-usage)) below       |                                                                                                                    |
+
+
+##### Client options - requestHeaders usage
+
+```php
+$woocommerce = new Client(
+    $url,
+    $consumer_key,
+    $consumer_secret,
+    [
+        'wp_api' => true,
+        'requestHeaders' => [
+            'Authorization' => 'Basic ' . base64_encode($username . ':' . $username),
+        ],
+    ]
+);
+```
+
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $woocommerce = new Client(
 | `query_string_auth` | `bool`   | no       | Force Basic Authentication as query string when `true` and using under HTTPS, default is `false`                       |
 | `oauth_timestamp`   | `string` | no       | Custom oAuth timestamp, default is `time()`                                                                            |
 | `user_agent`        | `string` | no       | Custom user-agent, default is `WooCommerce API Client-PHP`                                                             |
-| `requestHeaders`    | `array`  | no       | Custom Request Headers (see [Client options - requestHeaders usage](#client-options-requestheaders-usage)) below       |                                                                                                                    |
+| `requestHeaders`    | `array`  | no       | Custom Request Headers (see [Client options - requestHeaders usage](#client-options---requestheaders-usage)) below     |                                                                                                                    |
 
 
 ##### Client options - requestHeaders usage

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -196,6 +196,12 @@ class HttpClient
             $headers['Content-Type'] = 'application/json;charset=utf-8';
         }
 
+        if (!empty($this->options->getRequestHeaders())) {
+            foreach ($this->options->getRequestHeaders() as $key => $header) {
+                $headers[$key] = $header;
+            }
+        }
+
         return $headers;
     }
 

--- a/src/WooCommerce/HttpClient/Options.php
+++ b/src/WooCommerce/HttpClient/Options.php
@@ -146,4 +146,14 @@ class Options
         return isset($this->options['follow_redirects']) ? (bool) $this->options['follow_redirects'] : false;
 
     }
+
+    /**
+     * Get request headers.
+     *
+     * @return array
+     */
+    public function getRequestHeaders()
+    {
+        return isset($this->options['requestHeaders']) ? $this->options['requestHeaders'] : [];
+    }
 }


### PR DESCRIPTION
## Problem

If the site is restricted with Basic HTTP Authentication, you will get a `401 Unauthorized` response since it's currently not possible to pass in custom Request Headers. 

## How to recreate

1. Restrict the site with https://wiki.apache.org/httpd/PasswordBasicAuth
1. Make a call, e.g: `$woocommerce->get($endpoint, $parameters = [])`

## Expected result

Should be able to pass the Basic Authentication credentials as Request Headers and get a `200` response.

## Actual result

With this PR, if we pass in the following client option, we will get a `200` (instead of `401`) response.

```
'requestHeaders' => [
    'Authorization' => 'Basic ' . base64_encode($username . ':' . $username),
],
```