### PR TITLE
Fix `lookForErrors` Issue with 2.0.0

### DIFF
--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -338,8 +338,8 @@ class HttpClient
             $errors = isset($parsedResponse->errors) ? $parsedResponse->errors : $parsedResponse;
 
             if (is_array($errors)) {
-                $errorMessage = $errors[0]['message'];
-                $errorCode    = $errors[0]['code'];
+                $errorMessage = $errors[0]->message;
+                $errorCode    = $errors[0]->code;
             } else {
                 $errorMessage = $errors->message;
                 $errorCode    = $errors->code;


### PR DESCRIPTION
Fixes #167

```
PHP Fatal error:  Uncaught Error: Cannot use object of type stdClass as array in /vendor/automattic/woocommerce/src/WooCommerce/HttpClient/HttpClient.php:341

Stack trace:
#0 /vendor/automattic/woocommerce/src/WooCommerce/HttpClient/HttpClient.php(378): Automattic\WooCommerce\HttpClient\HttpClient->lookForErrors(Object(stdClass))
#1 /vendor/automattic/woocommerce/src/WooCommerce/HttpClient/HttpClient.php(414): Automattic\WooCommerce\HttpClient\HttpClient->processResponse()
#2 /vendor/automattic/woocommerce/src/WooCommerce/Client.php(82): Automattic\WooCommerce\HttpClient\HttpClient->request('orders', 'GET', Array, Array)
```

Example object:

```
array(1) {
  [0]=>
  object(stdClass)#44 (2) {
    ["code"]=>
    string(36) "woocommerce_api_authentication_error"
    ["message"]=>
    string(19) "API user is invalid"
  }
}
```