### PR TITLE
Testing against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ sudo: false
 
 php:
   - 5.4
+    dist: trusty
   - 5.5
+    dist: trusty
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,11 @@ language: php
 sudo: false
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
   - 7.4
-
-jobs:
-  include:
-    - php: 5.4
-      dist: trusty
-    - php: 5.5
-      dist: trusty
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,19 @@ language: php
 sudo: false
 
 php:
-  - 5.4
-    dist: trusty
-  - 5.5
-    dist: trusty
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
   - 7.4
+
+jobs:
+  include:
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0",
+    "phpunit/phpunit": "^7.0",
     "squizlabs/php_codesniffer": "3.*"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^6.0",
     "squizlabs/php_codesniffer": "3.*"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "*",
+    "phpunit/phpunit": "^7.0",
     "squizlabs/php_codesniffer": "3.*"
   },
   "autoload": {


### PR DESCRIPTION
This PR brings `master` back into a passing state.  A few changes are included:
 * No longer running tests against php 5.*
 * Now running tests against PHP 7.4 and the nightly build, which should help determine compatibility with future php versions as well (though `nightly` won't fail any PRs)
 * Locks phpunit into v6, because it's the version needed for all tests to still pass in these versions