### PR TITLE
Add the option to implement custom cURL options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 composer.lock
 vendor/
 run.php

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -60,6 +60,13 @@ class HttpClient
     protected $options;
 
     /**
+     * The custom cURL options to use in the requests.
+     *
+     * @var array
+     */
+    private $customCurlOptions = [];
+
+    /**
      * Request.
      *
      * @var Request
@@ -324,6 +331,10 @@ class HttpClient
         \curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, true);
         \curl_setopt($this->ch, CURLOPT_HTTPHEADER, $this->request->getRawHeaders());
         \curl_setopt($this->ch, CURLOPT_URL, $this->request->getUrl());
+
+        foreach ($this->customCurlOptions as $customCurlOptionKey => $customCurlOptionValue) {
+            \curl_setopt($this->ch, $customCurlOptionKey, $customCurlOptionValue);
+        }
     }
 
     /**
@@ -440,5 +451,15 @@ class HttpClient
     public function getResponse()
     {
         return $this->response;
+    }
+
+    /**
+     * Set custom cURL options to use in requests.
+     *
+     * @param array $curlOptions
+     */
+    public function setCustomCurlOptions(array $curlOptions)
+    {
+        $this->customCurlOptions = $curlOptions;
     }
 }


### PR DESCRIPTION
Adding a function to load custom CURL options to use with the HttpClient.

We needed this option for an implementation for a client, where we needed to set a specific HTTP version in CURL to work with their server.