### PR TITLE
`$parameters` should match `$this->getParameters`

### DIFF
--- a/src/WooCommerce/HttpClient/OAuth.php
+++ b/src/WooCommerce/HttpClient/OAuth.php
@@ -190,7 +190,7 @@ class OAuth
 
         // Normalize parameter key/values and sort them.
         $parameters = $this->normalizeParameters($parameters);
-        \uksort($parameters, 'strcmp');
+        $parameters = $this->getSortedParameters($parameters);
 
         // Set query string.
         $queryString  = \implode('%26', $this->joinWithEqualsSign($parameters)); // Join with ampersand.


### PR DESCRIPTION
Nested arrays doesn't get sorted automatically with `uksort()`, so if `$parameters` has nested array with more than 9 elements, `$parameters` differs from `$this->getParameters()` and more importantly from signed string `$stringToSign`, so OAuth throws an error: **"Invalid signature - provided signature does not match. [woocommerce_rest_authentication_error]"**.

### Example:

**$parameters**
```
[
  '_fields' => [
    0 => 'id',
    1 => 'name',
    2 => 'categories',
    3 => 'price',
    4 => 'permalink',
    5 => 'average_rating',
    6 => 'rating_count',
    7 => 'duration',
    8 => 'location',
    9 => 'display_price',
    10 => 'images'
  ]
  ...
];
```

**$this-getParameters();**
```
[
  '_fields' => [
    0 => 'id',
    1 => 'name',
    10 => 'images',
    2 => 'categories',
    3 => 'price',
    4 => 'permalink',
    5 => 'average_rating',
    6 => 'rating_count',
    7 => 'duration',
    8 => 'location',
    9 => 'display_price'
  ]
  ...
];
```