### PR TITLE
[Fix] each method do response with \stdClass not array

### DIFF
--- a/src/WooCommerce/Client.php
+++ b/src/WooCommerce/Client.php
@@ -49,7 +49,7 @@ class Client
      * @param string $endpoint API endpoint.
      * @param array  $data     Request data.
      *
-     * @return array
+     * @return \stdClass
      */
     public function post($endpoint, $data)
     {
@@ -62,7 +62,7 @@ class Client
      * @param string $endpoint API endpoint.
      * @param array  $data     Request data.
      *
-     * @return array
+     * @return \stdClass
      */
     public function put($endpoint, $data)
     {
@@ -75,7 +75,7 @@ class Client
      * @param string $endpoint   API endpoint.
      * @param array  $parameters Request parameters.
      *
-     * @return array
+     * @return \stdClass
      */
     public function get($endpoint, $parameters = [])
     {
@@ -88,7 +88,7 @@ class Client
      * @param string $endpoint   API endpoint.
      * @param array  $parameters Request parameters.
      *
-     * @return array
+     * @return \stdClass
      */
     public function delete($endpoint, $parameters = [])
     {
@@ -100,7 +100,7 @@ class Client
      *
      * @param string $endpoint API endpoint.
      *
-     * @return array
+     * @return \stdClass
      */
     public function options($endpoint)
     {

--- a/src/WooCommerce/HttpClient/HttpClient.php
+++ b/src/WooCommerce/HttpClient/HttpClient.php
@@ -359,7 +359,7 @@ class HttpClient
     /**
      * Process response.
      *
-     * @return array
+     * @return \stdClass
      */
     protected function processResponse()
     {
@@ -396,7 +396,7 @@ class HttpClient
      * @param array  $data       Request data.
      * @param array  $parameters Request parameters.
      *
-     * @return array
+     * @return \stdClass
      */
     public function request($endpoint, $method, $data = [], $parameters = [])
     {


### PR DESCRIPTION
Since v2.0.0 every method should response with a `\stdClass`, but the annotation still tells that an `array` get's returned.

Closes #252